### PR TITLE
#1: Add new mapped folder for Downloads in sandbox.wsb

### DIFF
--- a/sandbox.wsb
+++ b/sandbox.wsb
@@ -7,6 +7,10 @@
       <SandboxFolder>C:\sandbox</SandboxFolder>
     </MappedFolder>
     <MappedFolder>
+      <HostFolder>C:\temp\sandbox\Downloads</HostFolder>
+      <SandboxFolder>C:\Users\WDAGUtilityAccount\Downloads</SandboxFolder>
+    </MappedFolder>
+    <MappedFolder>
       <HostFolder>C:\temp\RootCA</HostFolder>
       <SandboxFolder>C:\CertStore</SandboxFolder>
       <ReadOnly>True</ReadOnly>


### PR DESCRIPTION
**Description:**
This pull request implements the folder mapping functionality to link the download folder from the host machine to the sandbox environment, as described in Issue 1.

**Changes Made:**
- Added folder mapping configuration in the `sandbox.wsb` file.
- The configuration maps the host's download folder to the sandbox's corresponding directory.
- With this setup, any file downloaded within the sandbox will automatically appear in the host's download folder.

**Details:**
In the `sandbox.wsb` file, a new mapped folder configuration has been added. This configuration establishes a link between the host and sandbox download folders. As a result, when files are downloaded within the sandbox, they are saved directly to the host's download folder, ensuring seamless access and transfer between environments.

**Testing:**
- Verified that files downloaded in the sandbox appear in the host's download folder.
- Ensured that the mapping does not interfere with other sandbox functionalities.

**Notes:**
- Security settings and permissions have been reviewed to ensure that the folder mapping does not introduce vulnerabilities.