### PR TITLE
2 disable powershell and cmd

### DIFF
--- a/configureSandbox.ps1
+++ b/configureSandbox.ps1
@@ -1,10 +1,28 @@
+# =======================================================================================================================================================================
+# Purpose : Sandbox configuration script for Windows 10/11
+#
+# DISCLAIMER: The sample scripts provided here are not supported under any Microsoft standard support program or service. 
+# All scripts are provided AS IS without warranty of any kind.
+# Microsoft further disclaims all implied warranties including, without limitation, any implied warranties of merchantability or of fitness for a particular purpose. 
+# The entire risk arising out of the use or performance of the sample scripts and documentation remains with you. 
+# In no event shall Microsoft, its authors, or anyone else involved in the creation, production, or delivery of the scripts be liable for any damages whatsoever 
+# (including, without limitation, damages for loss of business profits, business interruption, loss of business information, or other pecuniary loss) 
+# arising out of the use of or inability to use the sample scripts or documentation, even if Microsoft has been advised of the possibility of such damages. 
+# 
+# ======================================================================================================================================================================
+
+##############################################################
 # Install certificate
+##############################################################
 $params = @{
     Filepath = "C:\CertStore\<CERT-NAME>.cer"
     CertStoreLocation = "Cert:\LocalMachine\Root"
 }
 Import-Certificate @params
 
+##############################################################
+# Enable Camera and Microphone
+##############################################################
 # Ensure that the sub-key is created if it doesn't exist
 if (-not (Test-Path "HKLM:\Software\Policies\Microsoft\Windows\AppPrivacy")) {
     New-Item -Path "HKLM:\Software\Policies\Microsoft\Windows\AppPrivacy" -Force
@@ -15,7 +33,9 @@ New-ItemProperty -Path "HKLM:\Software\Policies\Microsoft\Windows\AppPrivacy" -N
 New-ItemProperty -Path "HKLM:\Software\Policies\Microsoft\Windows\AppPrivacy" -Name "LetAppsAccessCamera_ForceDenyTheseApps" -PropertyType MultiString -Force
 New-ItemProperty -Path "HKLM:\Software\Policies\Microsoft\Windows\AppPrivacy" -Name "LetAppsAccessCamera_UserInControlOfTheseApps" -PropertyType MultiString -Force
 
+##############################################################
 # Disable Powershell
+##############################################################
 $explorerKeyPath = "HKCU:\Software\Microsoft\Windows\CurrentVersion\Policies\Explorer"
 if (-not (Test-Path $explorerKeyPath)) {
     New-Item -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\Policies" -Name "Explorer" -Force
@@ -41,5 +61,7 @@ Stop-Process -Name explorer -Force
 Start-Process -WindowStyle hidden -Name "explorer.exe"
 Set-ExecutionPolicy -ExecutionPolicy Restricted -Scope LocalMachine
 
+##############################################################
 # Open Microsoft Edge with a specific URL (without kiosk mode)
+##############################################################
 Start-Process "msedge.exe" -Wait -WindowStyle Maximized -ArgumentList "https://www.microsoft.com"

--- a/configureSandbox.ps1
+++ b/configureSandbox.ps1
@@ -5,7 +5,15 @@ $params = @{
 }
 Import-Certificate @params
 
-
+# Ensure that the sub-key is created if it doesn't exist
+if (-not (Test-Path "HKLM:\Software\Policies\Microsoft\Windows\AppPrivacy")) {
+    New-Item -Path "HKLM:\Software\Policies\Microsoft\Windows\AppPrivacy" -Force
+}
+# Set the policy to allow apps access to the camera
+New-ItemProperty -Path "HKLM:\Software\Policies\Microsoft\Windows\AppPrivacy" -Name "LetAppsAccessCamera" -Value 1 -PropertyType DWord -Force
+New-ItemProperty -Path "HKLM:\Software\Policies\Microsoft\Windows\AppPrivacy" -Name "LetAppsAccessCamera_ForceAllowTheseApps" -PropertyType MultiString -Force
+New-ItemProperty -Path "HKLM:\Software\Policies\Microsoft\Windows\AppPrivacy" -Name "LetAppsAccessCamera_ForceDenyTheseApps" -PropertyType MultiString -Force
+New-ItemProperty -Path "HKLM:\Software\Policies\Microsoft\Windows\AppPrivacy" -Name "LetAppsAccessCamera_UserInControlOfTheseApps" -PropertyType MultiString -Force
 
 # Disable Powershell
 $explorerKeyPath = "HKCU:\Software\Microsoft\Windows\CurrentVersion\Policies\Explorer"
@@ -32,18 +40,6 @@ foreach ($program in $programsToBlock) {
 Stop-Process -Name explorer -Force
 Start-Process -WindowStyle hidden -Name "explorer.exe"
 Set-ExecutionPolicy -ExecutionPolicy Restricted -Scope LocalMachine
-
-
-
-# Ensure that the sub-key is created if it doesn't exist
-if (-not (Test-Path "HKLM:\Software\Policies\Microsoft\Windows\AppPrivacy")) {
-    New-Item -Path "HKLM:\Software\Policies\Microsoft\Windows\AppPrivacy" -Force
-}
-# Set the policy to allow apps access to the camera
-New-ItemProperty -Path "HKLM:\Software\Policies\Microsoft\Windows\AppPrivacy" -Name "LetAppsAccessCamera" -Value 1 -PropertyType DWord -Force
-New-ItemProperty -Path "HKLM:\Software\Policies\Microsoft\Windows\AppPrivacy" -Name "LetAppsAccessCamera_ForceAllowTheseApps" -PropertyType MultiString -Force
-New-ItemProperty -Path "HKLM:\Software\Policies\Microsoft\Windows\AppPrivacy" -Name "LetAppsAccessCamera_ForceDenyTheseApps" -PropertyType MultiString -Force
-New-ItemProperty -Path "HKLM:\Software\Policies\Microsoft\Windows\AppPrivacy" -Name "LetAppsAccessCamera_UserInControlOfTheseApps" -PropertyType MultiString -Force
 
 # Open Microsoft Edge with a specific URL (without kiosk mode)
 Start-Process "msedge.exe" -Wait -WindowStyle Maximized -ArgumentList "https://www.microsoft.com"


### PR DESCRIPTION
**Description:**
This pull request implements the configuration changes necessary to disable PowerShell and Command Prompt (CMD) within the sandbox environment, as described in Issue 2.

**Changes Made:**
- Configured policies to disable the execution of PowerShell and CMD.
- Added script to update registry settings and enforce policy restrictions.
- Applied changes to ensure immediate effect by restarting Windows Explorer and setting execution policies.

**Details:**
A script has been added that performs the following actions:
1. Creates the necessary registry path if it doesn't exist: `HKCU:\Software\Microsoft\Windows\CurrentVersion\Policies\Explorer`.
2. Sets the `DisallowRun` property to 1 to enable the program block list.
3. Creates and populates the `DisallowRun` list with the paths of `powershell.exe`, `C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe`, and `cmd.exe`.
4. Restarts Windows Explorer to apply these changes immediately.
5. Sets the PowerShell execution policy to `Restricted` for the local machine scope.

**Testing:**
- Verified that PowerShell and CMD are disabled and cannot be executed within the sandbox.
- Ensured no other functionalities are impacted by these restrictions.
- Restarted Explorer to confirm that changes take effect immediately.

**Notes:**
- The security settings have been reviewed to ensure these changes do not introduce vulnerabilities.
- Users should verify that no required scripts are blocked inadvertently by these restrictions.